### PR TITLE
ffmpeg libcaca option has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Giphy in your vim.
 
 * \*nix(-like) OS (for `mktemp`, etc.)
 * [webapi-vim](https://github.com/mattn/webapi-vim)
-* [ffmpeg](https://www.ffmpeg.org/) configured with `--with-libcaca`
+* [ffmpeg](https://www.ffmpeg.org/) configured with `--enable-libcaca`
 
 ## 2. Demo
 
@@ -16,7 +16,7 @@ Giphy in your vim.
 ### 3.1 Install Prerequisites
 #### 3.1.1 [ffmpeg](https://www.ffmpeg.org/)
 ##### OS X
-1. Run `brew install ffmpeg --with-libcaca`
+1. Run `brew install ffmpeg --enable-libcaca`
 
 #### 3.1.2 [webapi-vim](https://github.com/mattn/webapi-vim)
 ##### Vundle


### PR DESCRIPTION
now `--enable-libcaca`:
https://www.ffmpeg.org/ffmpeg-devices.html#caca
