### PR TITLE
Giphy is not available on starting (an empty) vim

### DIFF
--- a/plugin/giphy.vim
+++ b/plugin/giphy.vim
@@ -31,7 +31,7 @@ endfunction
 
 augroup giphy
     autocmd!
-    autocmd BufNewFile,BufReadPost * call giphy#init()
+    autocmd BufEnter,BufReadPost * call giphy#init()
 augroup END
 
 " Section: Giphy API


### PR DESCRIPTION
giphy initialization currently only occurs on file loads. This means if
you start a new empty vim the `:Giphy` command is not immediately
available, and only becomes available after loading a file.

Replacing `BufNewFile` with `BufEnter` resolves this issue and ensures
`:Giphy` is always available.
